### PR TITLE
Fix permissions on serializer fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 .tox/
 dist/
 *.egg-info/
+.idea/
+

--- a/rest_framework_serializer_field_permissions/fields.py
+++ b/rest_framework_serializer_field_permissions/fields.py
@@ -15,24 +15,23 @@ class PermissionMixin(object):
         return all((permission.has_permission(request) for permission in self.permission_classes))
 
 
-class _PermissionListSerializer(ListSerializer):
-    def __init__(self, *args, **kwargs):
-        self.child = kwargs.pop('child', copy.deepcopy(self.child))
-
-        self.permission_classes = self.child.permission_classes
-        self.check_permission = self.child.check_permission
-
-        self.allow_empty = kwargs.pop('allow_empty', True)
-
-        assert self.child is not None, '`child` is a required argument.'
-        assert not inspect.isclass(self.child), '`child` has not been instantiated.'
-
-        super(ListSerializer, self).__init__(*args, **kwargs)
-
-        self.child.bind(field_name='', parent=self)
-
-
 class SerializerPermissionMixin(PermissionMixin):
+    class PermissionListSerializer(ListSerializer):
+        def __init__(self, *args, **kwargs):
+            self.child = kwargs.pop('child', copy.deepcopy(self.child))
+
+            self.permission_classes = self.child.permission_classes
+            self.check_permission = self.child.check_permission
+
+            self.allow_empty = kwargs.pop('allow_empty', True)
+
+            assert self.child is not None, '`child` is a required argument.'
+            assert not inspect.isclass(self.child), '`child` has not been instantiated.'
+
+            super(ListSerializer, self).__init__(*args, **kwargs)
+
+            self.child.bind(field_name='', parent=self)
+
     @classmethod
     def many_init(cls, *args, **kwargs):
         child_serializer = cls(*args, **kwargs)
@@ -41,7 +40,7 @@ class SerializerPermissionMixin(PermissionMixin):
                                     (key, value) for key, value in kwargs.items()
                                     if key in LIST_SERIALIZER_KWARGS
                                     ]))
-        return _PermissionListSerializer(*args, **list_kwargs)
+        return SerializerPermissionMixin.PermissionListSerializer(*args, **list_kwargs)
 
 
 class BooleanField(PermissionMixin, fields.BooleanField):

--- a/rest_framework_serializer_field_permissions/fields.py
+++ b/rest_framework_serializer_field_permissions/fields.py
@@ -1,8 +1,10 @@
+import copy
+import inspect
 from rest_framework import fields
+from rest_framework.serializers import LIST_SERIALIZER_KWARGS, ListSerializer
 
 
 class PermissionMixin(object):
-
     def __init__(self, *args, **kwargs):
         permission_classes = kwargs.pop("permission_classes", ())
 
@@ -11,6 +13,35 @@ class PermissionMixin(object):
 
     def check_permission(self, request):
         return all((permission.has_permission(request) for permission in self.permission_classes))
+
+
+class _PermissionListSerializer(ListSerializer):
+    def __init__(self, *args, **kwargs):
+        self.child = kwargs.pop('child', copy.deepcopy(self.child))
+
+        self.permission_classes = self.child.permission_classes
+        self.check_permission = self.child.check_permission
+
+        self.allow_empty = kwargs.pop('allow_empty', True)
+
+        assert self.child is not None, '`child` is a required argument.'
+        assert not inspect.isclass(self.child), '`child` has not been instantiated.'
+
+        super(ListSerializer, self).__init__(*args, **kwargs)
+
+        self.child.bind(field_name='', parent=self)
+
+
+class SerializerPermissionMixin(PermissionMixin):
+    @classmethod
+    def many_init(cls, *args, **kwargs):
+        child_serializer = cls(*args, **kwargs)
+        list_kwargs = {'child': child_serializer}
+        list_kwargs.update(dict([
+                                    (key, value) for key, value in kwargs.items()
+                                    if key in LIST_SERIALIZER_KWARGS
+                                    ]))
+        return _PermissionListSerializer(*args, **list_kwargs)
 
 
 class BooleanField(PermissionMixin, fields.BooleanField):
@@ -99,19 +130,3 @@ class ModelField(PermissionMixin, fields.ModelField):
 
 class SerializerMethodField(PermissionMixin, fields.SerializerMethodField):
     pass
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/rest_framework_serializer_field_permissions/serializers.py
+++ b/rest_framework_serializer_field_permissions/serializers.py
@@ -1,9 +1,4 @@
-from rest_framework.pagination import PaginationSerializer, DefaultObjectSerializer
-from rest_framework.serializers import ListSerializer
-
-
 class FieldPermissionSerializerMixin(object):
-
     @property
     def fields(self):
         ret = super(FieldPermissionSerializerMixin, self).fields
@@ -16,21 +11,25 @@ class FieldPermissionSerializerMixin(object):
         return ret
 
 
-class ContextPassingPaginationSerializer(PaginationSerializer):
+"""
+Django REST Framework 3.1+ killed PaginationSerializer and DefaultObjectSerializer
+"""
 
-    def __init__(self, *args, **kwargs):
-        """
-        Override init to add in the object serializer field on-the-fly.
-        """
-        super(ContextPassingPaginationSerializer, self).__init__(*args, **kwargs)
-        results_field = self.results_field
 
-        try:
-            object_serializer = self.Meta.object_serializer_class
-        except AttributeError:
-            object_serializer = DefaultObjectSerializer
-
-        self.fields[results_field] = ListSerializer(
-            child=object_serializer(context=kwargs["context"]),
-            source='object_list'
-        )
+# class ContextPassingPaginationSerializer(PaginationSerializer):
+#     def __init__(self, *args, **kwargs):
+#         """
+#         Override init to add in the object serializer field on-the-fly.
+#         """
+#         super(ContextPassingPaginationSerializer, self).__init__(*args, **kwargs)
+#         results_field = self.results_field
+#
+#         try:
+#             object_serializer = self.Meta.object_serializer_class
+#         except AttributeError:
+#             object_serializer = DefaultObjectSerializer
+#
+#         self.fields[results_field] = ListSerializer(
+#             child=object_serializer(context=kwargs["context"]),
+#             source='object_list'
+#         )

--- a/rest_framework_serializer_field_permissions/test_app/__init__.py
+++ b/rest_framework_serializer_field_permissions/test_app/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'kwong93'

--- a/rest_framework_serializer_field_permissions/test_app/models.py
+++ b/rest_framework_serializer_field_permissions/test_app/models.py
@@ -1,0 +1,13 @@
+from django.db import models
+
+
+class Album(models.Model):
+    album_name = models.TextField()
+    artist = models.TextField()
+
+
+class Track(models.Model):
+    duration = models.IntegerField()
+    order = models.TextField()
+    title = models.TextField()
+    album = models.ForeignKey(to=Album, related_name='tracks')

--- a/rest_framework_serializer_field_permissions/tests/runtests.py
+++ b/rest_framework_serializer_field_permissions/tests/runtests.py
@@ -15,6 +15,7 @@ sys.path.append(os.path.abspath(os.path.join(BASE_DIR, '..')))
 # decorator, because it would miss the database setup.
 CUSTOM_INSTALLED_APPS = (
     'rest_framework',
+    'test_app'
 )
 
 ALWAYS_INSTALLED_APPS = (

--- a/rest_framework_serializer_field_permissions/tests/tests.py
+++ b/rest_framework_serializer_field_permissions/tests/tests.py
@@ -93,6 +93,16 @@ class SerializerFieldTests(TestCase):
                              title='Public Service Announcement',
                              duration=245)
 
+    def get_album_serializer(self, _tracks):
+        class AlbumSerializer(FieldPermissionSerializerMixin, serializers.ModelSerializer):
+            tracks = _tracks
+
+            class Meta:
+                model = Album
+                fields = ('album_name', 'artist', 'tracks')
+
+        return AlbumSerializer
+
     def test_many_false_serializer_field(self):
         field = TrackSerializer(permission_classes=(AllowNone(),))
         self.assertFalse(field.check_permission({}))
@@ -103,25 +113,15 @@ class SerializerFieldTests(TestCase):
         self.assertFalse(field.check_permission({}))
 
     def test_many_false_serializer_field_removed(self):
-        class AlbumSerializer(FieldPermissionSerializerMixin, serializers.ModelSerializer):
-            tracks = TrackSerializer(permission_classes=(AllowNone(),))
+        tracks = TrackSerializer(permission_classes=(AllowNone(),))
 
-            class Meta:
-                model = Album
-                fields = ('album_name', 'artist', 'tracks')
-
-        album_serializer = AlbumSerializer(instance=self.album, context={'request': {}})
+        album_serializer = self.get_album_serializer(tracks)(instance=self.album, context={'request': {}})
 
         self.assertFalse('tracks' in album_serializer.data)
 
     def test_many_true_serializer_field_removed(self):
-        class AlbumSerializer(FieldPermissionSerializerMixin, serializers.ModelSerializer):
-            tracks = TrackSerializer(permission_classes=(AllowNone(),), many=True)
+        tracks = TrackSerializer(permission_classes=(AllowNone(),), many=True)
 
-            class Meta:
-                model = Album
-                fields = ('album_name', 'artist', 'tracks')
-
-        album_serializer = AlbumSerializer(instance=self.album, context={'request': {}})
+        album_serializer = self.get_album_serializer(tracks)(instance=self.album, context={'request': {}})
 
         self.assertFalse('tracks' in album_serializer.data)

--- a/rest_framework_serializer_field_permissions/tests/tests.py
+++ b/rest_framework_serializer_field_permissions/tests/tests.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 from rest_framework import serializers
 
 from rest_framework_serializer_field_permissions.permissions import AllowAny, AllowNone, IsAuthenticated
-from rest_framework_serializer_field_permissions.fields import BooleanField, PermissionMixin
+from rest_framework_serializer_field_permissions.fields import BooleanField, SerializerPermissionMixin
 from rest_framework_serializer_field_permissions.serializers import FieldPermissionSerializerMixin
 from test_app.models import Album, Track
 
@@ -77,7 +77,7 @@ class FieldTests(TestCase):
         self.assertTrue(field.check_permission({}))
 
 
-class TrackSerializer(PermissionMixin, serializers.ModelSerializer):
+class TrackSerializer(SerializerPermissionMixin, serializers.ModelSerializer):
     class Meta:
         model = Track
         fields = ('order', 'title')


### PR DESCRIPTION
I was working with emptyflash on this one to resolve issue #1. Added some tests for serializer field permissions, failing for serializers defined with many=True.
