### PR TITLE
Add support for JSONField

### DIFF
--- a/rest_framework_serializer_field_permissions/fields.py
+++ b/rest_framework_serializer_field_permissions/fields.py
@@ -182,3 +182,8 @@ class ModelField(PermissionMixin, fields.ModelField):
 # pylint: disable=abstract-method
 class SerializerMethodField(PermissionMixin, fields.SerializerMethodField):
     pass
+
+
+# pylint: disable=missing-docstring
+class JSONField(PermissionMixin, fields.JSONField):
+    pass


### PR DESCRIPTION
This PR adds support for DRF [JSONField](https://www.django-rest-framework.org/api-guide/fields/#jsonfield)s, #26 