### PR TITLE
Revert "Add support for JSONField"

### DIFF
--- a/rest_framework_serializer_field_permissions/fields.py
+++ b/rest_framework_serializer_field_permissions/fields.py
@@ -182,8 +182,3 @@ class ModelField(PermissionMixin, fields.ModelField):
 # pylint: disable=abstract-method
 class SerializerMethodField(PermissionMixin, fields.SerializerMethodField):
     pass
-
-
-# pylint: disable=missing-docstring
-class JSONField(PermissionMixin, fields.JSONField):
-    pass


### PR DESCRIPTION
Reverts InterSIS/django-rest-serializer-field-permissions#27

I realized that I already have this change staged in branch 4.0.0, under discussion in https://github.com/InterSIS/django-rest-serializer-field-permissions/issues/26 .