### PR TITLE
Tox update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,12 @@ matrix:
       dist: xenial
       sudo: true
       env:
-        - TOX_ENV=py37-django3.0-drf3.11
-    - python: 3.7
+        - TOX_ENV=py37-django{2.2,3.1,3.2}-drf{3.11,3.12}
+    - python: 3.9
       dist: xenial
       sudo: true
       env:
-        - TOX_ENV=py37-django2.2-drf3.11
+        - TOX_ENV=py39-django{2.2,3.1,3.2}-drf{3.11,3.12}
   fast_finish: true
 
 install:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     author='The Intersis Foundation',
     author_email='dev@intersis.org',
     install_requires=[
-        'django>=2.1',
+        'django>=2.2',
         'djangorestframework~=3.0',
     ],
     classifiers=[
@@ -31,6 +31,7 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
-       {py37}-django{2.2,3.0}-drf{3.11},
-       {py39}-django{3.2}-drf{3.11},
+       {py37,py39}-django{2.2,3.1,3.2}-drf{3.11,3.12}
        lint,
        coveralls
 
@@ -29,7 +28,8 @@ commands =
 commands = python rest_framework_serializer_field_permissions/tests/runtests.py
 
 deps =
-       django3.0: Django==3.0.7
-       django2.2: Django==2.2.9
-       django3.2: Django==3.2.4
-       drf3.11: djangorestframework==3.11.0
+       django2.2: Django>=2.2,<3.0
+       django3.1: Django>=3.1,<3.2
+       django3.2: Django>=3.2,<4.0
+       drf3.11: djangorestframework>=3.11<3.12
+       drf3.12: djangorestframework>=3.12<3.13

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
        {py37}-django{2.2,3.0}-drf{3.11},
+       {py39}-django{3.2}-drf{3.11},
        lint,
        coveralls
 
@@ -30,4 +31,5 @@ commands = python rest_framework_serializer_field_permissions/tests/runtests.py
 deps =
        django3.0: Django==3.0.7
        django2.2: Django==2.2.9
+       django3.2: Django==3.2.4
        drf3.11: djangorestframework==3.11.0


### PR DESCRIPTION
Changes:

- Added python 3.9 testing
- Updated to test for django 2.2, 3.1, and 3.2
- Updated to test for drf 3.11 latest, and 3.12 latest
- Changed .travis.yml to take into the account the changes in fewer
  entries.

Added testing to reflect Django's support matrix as of today:

- 2.2 LTS, April 2022
- 3.1, December 2021
- 3.2 LTS, April 2024