### PR TITLE
Remove NullBooleanField in order to make it compatible with Django 4.x

### DIFF
--- a/rest_framework_serializer_field_permissions/fields.py
+++ b/rest_framework_serializer_field_permissions/fields.py
@@ -77,11 +77,6 @@ class BooleanField(PermissionMixin, fields.BooleanField):
 
 
 # pylint: disable=missing-docstring
-class NullBooleanField(PermissionMixin, fields.NullBooleanField):
-    pass
-
-
-# pylint: disable=missing-docstring
 class CharField(PermissionMixin, fields.CharField):
     pass
 


### PR DESCRIPTION
## What

NullBooleanField has been removed from Django 4.x
https://code.djangoproject.com/ticket/31369

## Goal

To make this library compatible with Django 4.x
we have to remove NullBooleanField

## Changes

To make the transition, you have to update your codebase like this:

from 

```python
NullBooleanField()
```

to

```python
BooleanField(allow_null=True, default=None)
```