### PR TITLE
Django 4.2 Compatibility

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing
+
+This document contains technical instructions for how to develop this package. See [the readme](README.md) for a description of what kinds of changes might be accepted. 
+
+## Installing Development Requirements
+
+First, create a virtual environment with the version of Python specified in [the tox file](tox.ini).
+
+Then, install the development requirements:
+
+```bash
+$ pip install -e .[dev]
+```
+
+## Running Tests
+
+Use tox to run tests against all supported versions:
+
+```bash
+$ tox
+```
+
+## Publishing the Library
+
+Make sure that you've updated the library version in [`setup.py`](setup.py). Then build and publish the library:
+
+```bash
+$ python setup.py sdist
+$ python -m twine upload dist/*
+```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Build Status](https://travis-ci.org/InterSIS/django-rest-serializer-field-permissions.svg?branch=master)](https://travis-ci.org/InterSIS/django-rest-serializer-field-permissions)
 [![Code Climate](https://codeclimate.com/github/InterSIS/django-rest-serializer-field-permissions/badges/gpa.svg)](https://codeclimate.com/github/InterSIS/django-rest-serializer-field-permissions)
 [![Coverage Status](https://coveralls.io/repos/InterSIS/django-rest-serializer-field-permissions/badge.svg?branch=master&service=github)](https://coveralls.io/github/InterSIS/django-rest-serializer-field-permissions?branch=master)
 [![PyPI version](https://badge.fury.io/py/django-rest-serializer-field-permissions.svg)](http://badge.fury.io/py/django-rest-serializer-field-permissions)

--- a/README.md
+++ b/README.md
@@ -160,8 +160,8 @@ Compatibility
 
 This package is tested for compatibility against the following software versions:
 
-* Django Rest Framework 3.11
-* Django 2.2, 3.0
+* Django Rest Framework 3.14.0
+* Django 3.2, 4.2
 * Python 3.7
 
 This package may incidentally be compatible with other similar versions of the above software. See tox.ini for specific minor versions tested.

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ This package is tested for compatibility against the following software versions
 
 * Django Rest Framework 3.14.0
 * Django 3.2, 4.2
-* Python 3.7
+* Python 3.8
 
 This package may incidentally be compatible with other similar versions of the above software. See tox.ini for specific minor versions tested.
 

--- a/rest_framework_serializer_field_permissions/fields.py
+++ b/rest_framework_serializer_field_permissions/fields.py
@@ -76,8 +76,11 @@ class BooleanField(PermissionMixin, fields.BooleanField):
     pass
 
 
-# pylint: disable=missing-docstring
-class NullBooleanField(PermissionMixin, fields.NullBooleanField):
+try:
+    # pylint: disable=missing-docstring
+    class NullBooleanField(PermissionMixin, fields.NullBooleanField):
+        pass
+except ImportError:
     pass
 
 

--- a/rest_framework_serializer_field_permissions/fields.py
+++ b/rest_framework_serializer_field_permissions/fields.py
@@ -80,7 +80,7 @@ try:
     # pylint: disable=missing-docstring
     class NullBooleanField(PermissionMixin, fields.NullBooleanField):
         pass
-except ImportError:
+except AttributeError:
     pass
 
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-rest-serializer-field-permissions',
-    version='4.1.0rc1',
+    version='4.1.0',
     packages=['rest_framework_serializer_field_permissions'],
     include_package_data=True,
     license='GNU General Public License v3 (GPLv3)',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-rest-serializer-field-permissions',
-    version='4.0.0',
+    version='4.1.0rc1',
     packages=['rest_framework_serializer_field_permissions'],
     include_package_data=True,
     license='GNU General Public License v3 (GPLv3)',
@@ -23,6 +23,12 @@ setup(
         'django>=3.0',
         'djangorestframework~=3.0',
     ],
+    extras_require={
+        'dev': [
+            'tox',
+            'twine',
+        ]
+    },
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     author='The Intersis Foundation',
     author_email='dev@intersis.org',
     install_requires=[
-        'django>=2.1',
+        'django>=3.0',
         'djangorestframework~=3.0',
     ],
     classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-       {py37}-django{2.2,3.0}-drf{3.11},
+       {py38}-django{3.2,4.2}-drf{3.14},
        lint,
        coveralls
 
@@ -16,8 +16,8 @@ passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 
 deps =
        coveralls
-       Django==2.1.1
-       djangorestframework==3.8.2
+       Django==4.2
+       djangorestframework==3.14.0
        pycrypto==2.6.1
 
 commands =
@@ -28,6 +28,6 @@ commands =
 commands = python rest_framework_serializer_field_permissions/tests/runtests.py
 
 deps =
-       django3.0: Django==3.0.7
-       django2.2: Django==2.2.9
-       drf3.11: djangorestframework==3.11.0
+       django3.2: Django==3.2.18
+       django4.2: Django==4.2
+       drf3.14: djangorestframework==3.14.0


### PR DESCRIPTION
Django 4.x removes the NullBooleanField type. This removes the exception encountered when trying to import this field.